### PR TITLE
Add new chip images to main page slides

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,15 @@
 
         /* Hero slide backgrounds */
         .bg-microchips {
-            background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+            background-image: url('advanced microchip.jpg');
+            background-size: cover;
+            background-position: center;
+        }
+        
+        .bg-neuromorphic {
+            background-image: url('Neuromorphic Technology.png');
+            background-size: cover;
+            background-position: center;
         }
         
         .bg-fpga {
@@ -276,6 +284,24 @@
                                 <p class="text-gray-300">Advanced lithography solutions enabling next-generation semiconductor fabrication.</p>
                                 <a href="hardware.html" class="inline-block bg-cyan-400 text-slate-900 font-semibold px-6 py-3 rounded-md hover:bg-cyan-300 transition">
                                     Learn More
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Slide 6: Neuromorphic Chips -->
+                    <div class="swiper-slide relative">
+                        <div class="absolute inset-0 bg-neuromorphic"></div>
+                        <div class="absolute inset-0 bg-[#001933]/70"></div>
+                        <div class="relative z-10 flex items-center h-full px-6 md:px-20">
+                            <div class="max-w-xl space-y-6">
+                                <p class="text-cyan-400 uppercase tracking-wider">Brain-Inspired Computing</p>
+                                <h1 class="text-white text-4xl md:text-6xl font-extrabold leading-tight uppercase">
+                                    Neuromorphic Chips
+                                </h1>
+                                <p class="text-gray-300">Revolutionary brain-inspired processors enabling ultra-low power AI and cognitive computing applications.</p>
+                                <a href="hardware.html" class="inline-block bg-cyan-400 text-slate-900 font-semibold px-6 py-3 rounded-md hover:bg-cyan-300 transition">
+                                    Discover More
                                 </a>
                             </div>
                         </div>


### PR DESCRIPTION
Update main page slider to incorporate new images and add a dedicated slide for Neuromorphic Chips.

---
<a href="https://cursor.com/background-agent?bcId=bc-7726c5f2-f623-4598-bb8e-f05b982b2164">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7726c5f2-f623-4598-bb8e-f05b982b2164">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

